### PR TITLE
Fix default cursor appearing on clickable hover targets

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -11,12 +11,19 @@
 }
 
 html,
+body,
+*,
+*::before,
+*::after {
+  cursor: none !important;
+}
+
+html,
 body {
   margin: 0;
   background: var(--bg);
   color: var(--text);
   font-family: "Space Grotesk", sans-serif;
-  cursor: none;
 }
 
 img,
@@ -182,7 +189,6 @@ h2 {
   position: relative;
   border-radius: 16px;
   overflow: hidden;
-  cursor: pointer;
   min-height: 320px;
 }
 
@@ -308,10 +314,6 @@ h2 {
 }
 
 @media (max-width: 720px) {
-  body {
-    cursor: auto;
-  }
-
   .cursor {
     display: none;
   }


### PR DESCRIPTION
### Motivation
- Ensure the OS cursor remains hidden everywhere including interactive elements so the site uses its custom cursor UI consistently.
- Prevent component-level CSS (like clickable cards and buttons) from overriding the global cursor hiding rule.

### Description
- Added an explicit global rule `html, body, *, *::before, *::after { cursor: none !important; }` to `styles.css` to force-hide the system cursor across all elements and pseudo-elements.
- Removed the `.film-card { cursor: pointer; }` declaration that caused the system pointer to reappear on hover for clickable cards.
- Removed the mobile override `body { cursor: auto }` inside the small-viewport media query so the cursor remains hidden on narrow screens.
- Changes are contained in `styles.css` and adjust the cascade so interactive targets no longer fall back to the native cursor.

### Testing
- Ran a local server with `python -m http.server 4173` and verified the site was served successfully.
- Executed a Playwright check using Firefox which confirmed computed styles for `.btn`, `.film-card`, and `body` were all `'none'` and produced the screenshot `artifacts/cursor-hidden-buttons.png` (success).
- Attempted the same Playwright run with Chromium which failed to launch in the environment due to a headless process error, but the Firefox run validated the intended behavior (Chromium failure unrelated to CSS changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699141f035108332a3c3f267fe81fee5)