### PR TITLE
Add full-screen Video Detail view with /video/:id routing

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -244,6 +244,91 @@ h2 {
   color: var(--muted);
 }
 
+
+.film-title-link {
+  color: var(--text);
+  text-underline-offset: 0.18em;
+  text-decoration-thickness: 0.08em;
+}
+
+.film-title-link:hover,
+.film-title-link:focus-visible {
+  color: var(--accent);
+}
+
+.video-detail-layer {
+  position: fixed;
+  inset: 0;
+  z-index: 120;
+}
+
+.video-detail-layer[hidden] {
+  display: none;
+}
+
+.video-detail {
+  min-height: 100svh;
+  width: 100%;
+  overflow-y: auto;
+  background: rgba(8, 8, 8, 0.97);
+  backdrop-filter: blur(14px);
+  padding: clamp(1rem, 3vw, 2rem);
+}
+
+.video-detail-close {
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  background: transparent;
+  color: var(--text);
+  border-radius: 999px;
+  padding: 0.55rem 1rem;
+  font-weight: 600;
+}
+
+.video-detail-content {
+  max-width: 1200px;
+  margin: 1rem auto 0;
+  display: grid;
+  gap: clamp(1.2rem, 2.4vw, 2rem);
+  grid-template-columns: 2fr 1fr;
+  align-items: start;
+}
+
+.video-detail-player-wrap {
+  aspect-ratio: 16 / 9;
+  background: #000;
+  border-radius: 14px;
+  overflow: hidden;
+  border: 1px solid #2f2f2f;
+}
+
+.video-detail-player-wrap iframe {
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+
+.video-detail-meta {
+  background: rgba(20, 20, 20, 0.9);
+  border: 1px solid #2a2a2a;
+  border-radius: 14px;
+  padding: 1.1rem;
+}
+
+.video-detail-meta p {
+  color: #d4d4d4;
+  line-height: 1.55;
+}
+
+.video-detail-role {
+  color: var(--accent) !important;
+  font-size: 0.95rem;
+  margin-top: 1rem;
+}
+
+body.video-detail-open {
+  overflow: hidden;
+}
+
 .project-track {
   display: grid;
   gap: 1rem;
@@ -294,6 +379,10 @@ h2 {
 
 @media (max-width: 900px) {
   .about-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .video-detail-content {
     grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
### Motivation
- Provide a full-screen Video Detail view when a user clicks a film title so the player, full title, description, and metadata are presented on a dedicated overlay/route.
- Keep existing inline playback behavior when users click the play button/thumbnail on the list page.
- Support direct linking and browser navigation so `/video/:id` opens the same full-screen detail view.

### Description
- Added a URL-synced full-screen detail overlay implemented in `script.js` with helpers `openVideoDetail`, `closeVideoDetail`, `renderVideoDetailFullScreen`, route parsing `parseVideoRoute`, and small routing state in `appRouteState`.
- Made each film title a keyboard-accessible link (`<a href="/video/:id">`) that opens the detail view without breaking the play-button inline behavior; preserved the original thumbnail/play code path.
- Implemented accessibility and UX behavior: focus is moved to the close button when opening, Escape closes the overlay, close/back button restores prior focus when possible, and `popstate` + direct-load support handle history navigation and `/video/:id` direct links.
- Added overlay and responsive styles in `styles.css` (`.video-detail-layer`, `.video-detail`, `.video-detail-content`, `.video-detail-close`, plus `.film-title-link`) to present the player and metadata in a two-column layout on desktop and single column on mobile.

### Testing
- Ran `node --check script.js` to validate JS syntax; check passed.
- Served the site locally with `python3 -m http.server 4173` and ran an automated Playwright script that validated title click opens detail and updates the URL, pressing Escape closes the view, and clicking the inline play button still loads an iframe player; all Playwright checks passed.
- Manual render validation: full-screen overlay styling and responsive layout applied via the updated `styles.css` (visual confirmation captured during browser run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992708442c88332b6a49835d0ac3bb9)