### PR TITLE
Fix Say Hello button behavior in contact section

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,7 +109,15 @@
       <section class="section contact" id="contact">
         <h2>Let’s build something unforgettable.</h2>
         <p>Open to collaborations, internships, and creative conversations.</p>
-        <a class="btn primary magnetic" href="mailto:g13901913371@gmail.com">Say Hello</a>
+        <a
+          class="btn primary magnetic"
+          href="mailto:g13901913371@gmail.com?subject=Hello%20Andrew"
+          data-say-hello
+          data-email="g13901913371@gmail.com"
+        >
+          Say Hello
+        </a>
+        <p class="contact-feedback" data-contact-feedback aria-live="polite" hidden></p>
       </section>
     </main>
 

--- a/script.js
+++ b/script.js
@@ -389,6 +389,32 @@ function initializeSmoothScroll() {
   requestAnimationFrame(raf);
 }
 
+
+function initializeContactCta() {
+  const sayHelloLink = document.querySelector('[data-say-hello]');
+  if (!sayHelloLink) {
+    logMissingElement('[data-say-hello]');
+    return;
+  }
+
+  const feedback = document.querySelector('[data-contact-feedback]');
+  const contactEmail = sayHelloLink.dataset.email || '';
+
+  sayHelloLink.addEventListener('click', async () => {
+    if (!navigator.clipboard || !contactEmail) return;
+
+    try {
+      await navigator.clipboard.writeText(contactEmail);
+      if (feedback) {
+        feedback.hidden = false;
+        feedback.textContent = `If your mail app did not open, the address was copied: ${contactEmail}`;
+      }
+    } catch (error) {
+      // Clipboard access can fail in restricted browser contexts; mailto link still works.
+    }
+  });
+}
+
 function initializeCursorAndNav() {
   const cursor = document.querySelector('.cursor');
   const nav = document.querySelector('.site-nav');
@@ -443,5 +469,6 @@ document.addEventListener('DOMContentLoaded', () => {
   initializeFilmShowcase();
   initializeAnimation();
   initializeSmoothScroll();
+  initializeContactCta();
   initializeCursorAndNav();
 });

--- a/styles.css
+++ b/styles.css
@@ -155,6 +155,14 @@ h2 {
   justify-content: center;
 }
 
+.contact-feedback {
+  flex-basis: 100%;
+  margin: 0;
+  color: var(--muted);
+  text-align: center;
+  font-size: 0.92rem;
+}
+
 .btn {
   padding: 0.72rem 1.2rem;
   border: 1px solid rgba(255, 255, 255, 0.3);


### PR DESCRIPTION
### Motivation
- The contact CTA could fail to open a mail app and left no guidance for users, so the action needed a reliable fallback and clear JS hooks.

### Description
- Updated the contact markup in `index.html` to use a pre-filled `mailto:` subject and to add `data-say-hello` and `data-email` attributes plus a live-region feedback element (`data-contact-feedback`).
- Implemented `initializeContactCta()` in `script.js` to copy the contact email to the clipboard on click and reveal a non-intrusive fallback message if the mail client does not open. 
- Hooked `initializeContactCta()` into page startup by calling it from `DOMContentLoaded` and kept the original mailto behavior as the primary action.
- Added `.contact-feedback` styles in `styles.css` so the feedback message displays cleanly beneath the CTA.

### Testing
- Ran `node --check script.js` and it completed successfully.
- Served the site with `python -m http.server 4173` and validated behavior via an automated browser script that loaded the page, clicked the `a[data-say-hello]` element, and captured a screenshot, which completed successfully.
- All automated checks passed (script syntax check and headless browser interaction).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699278207b94833293a98ea3966d7f60)