### PR TITLE
Make Film Showcase YouTube embeds resilient with external fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,11 @@
 ---
 
 A starter film site for andalagy that already knows it will expire, built to feel certain for a moment and then quietly fall behind. The recommendations arrive with confidence, the lists pretending to be fixed, even as new releases stack up and old opinions start to slip. Nothing is meant to last for long; taste shifts, context changes, relevance erodes.
+
+## Optional YouTube Data API setup
+
+If you want embeddable detection to use YouTube Data API v3 first (before iframe probing), inject a runtime key as:
+
+- `window.FILM_SITE_CONFIG = { youtubeApiKey: 'YOUR_KEY' }`
+
+This value should come from your deployment environment variable (for example `YOUTUBE_DATA_API_KEY`) and must never be hardcoded in `script.js`.

--- a/styles.css
+++ b/styles.css
@@ -252,6 +252,17 @@ h2 {
   color: var(--muted);
 }
 
+.external-only-label {
+  margin-top: 0.45rem !important;
+  display: inline-block;
+  padding: 0.2rem 0.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  border-radius: 999px;
+  font-size: 0.75rem;
+  letter-spacing: 0.02em;
+  color: #f3d27a !important;
+}
+
 
 .film-title-link {
   color: var(--text);
@@ -313,6 +324,21 @@ h2 {
   width: 100%;
   height: 100%;
   border: 0;
+}
+
+.video-detail-fallback {
+  height: 100%;
+  display: grid;
+  place-content: center;
+  justify-items: center;
+  gap: 0.8rem;
+  padding: 1rem;
+  text-align: center;
+}
+
+.video-detail-fallback p {
+  margin: 0;
+  color: var(--muted);
 }
 
 .video-detail-meta {


### PR DESCRIPTION
### Motivation
- Some YouTube watch URLs in the films list were not embeddable and produced broken in-page players, so clicking a card could fail; the change ensures every film remains clickable and functional.
- The goal is to keep the original `films` array shape unchanged while deriving `videoId`, `embedUrl`, `watchUrl`, and `isEmbeddable` at runtime and providing a robust fallback for non-embeddable videos.

### Description
- Added URL helpers and derived runtime fields: `parseVideoId`, `toWatchUrl`, `toEmbedUrl`, and `deriveFilmData`, and introduced `filmRuntimeState` to store derived film entries with `videoId`, `embedUrl`, `watchUrl`, and `isEmbeddable`.
- Implemented embeddable detection pipeline: optional YouTube Data API v3 (`videos.list?part=status`) when a runtime API key is present, falling back to YouTube Iframe API probing when no key or when the API check fails; defensive logging and timeouts are included.
- Updated card and modal behavior so embeddable videos open in an in-page iframe modal while non-embeddable videos open the YouTube watch page in a new tab and render a small `Watch on YouTube` label on the card and a modal fallback CTA.
- Added safe error handling to avoid uncaught promise rejections, small helper `openExternalVideo`, style updates for the external-only label and modal fallback, and a README note explaining runtime API key injection (no hardcoded keys).

### Testing
- Ran `node --check script.js` to validate the script syntax and it succeeded.
- Attempted an automated Playwright screenshot run to validate the page flow, but the Chromium process crashed in this container environment (SIGSEGV), so the browser-based capture failed; the script degrades gracefully in that environment and logs the failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69927a76c7e08332817b908f0cf51b13)