### PR TITLE
Fix deterministic YouTube thumbnails for film cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,6 +124,7 @@
     <script defer src="https://cdn.jsdelivr.net/npm/gsap@3.12.5/dist/gsap.min.js"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/gsap@3.12.5/dist/ScrollTrigger.min.js"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/@studio-freight/lenis@1.0.42/bundled/lenis.min.js"></script>
+    <script defer src="youtube-utils.js"></script>
     <script defer src="script.js"></script>
   </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -234,23 +234,21 @@ h2 {
 
 .video-shell iframe,
 .video-shell img,
-.video-shell button {
+.video-shell .video-thumb-link {
   position: absolute;
   inset: 0;
   width: 100%;
   height: 100%;
 }
 
+.video-shell .video-thumb-link {
+  display: block;
+}
+
 .video-shell img {
   object-fit: cover;
 }
 
-.play-video {
-  border: 0;
-  background: transparent;
-  padding: 0;
-  color: inherit;
-}
 
 /* Overlay elements ignore pointer events so the click lands on the button without interfering with custom cursors. */
 .video-overlay,

--- a/youtube-utils.js
+++ b/youtube-utils.js
@@ -1,0 +1,49 @@
+(function attachYouTubeUtils(globalScope) {
+  function cleanVideoId(value) {
+    if (!value) return null;
+    return value.split(/[?#]/)[0].trim() || null;
+  }
+
+  function extractYouTubeVideoId(url) {
+    try {
+      const parsed = new URL(url);
+      const host = parsed.hostname.replace(/^www\./, '');
+
+      if (host === 'youtu.be') {
+        const shortId = cleanVideoId(parsed.pathname.replace(/^\//, '').split('/')[0]);
+        return shortId;
+      }
+
+      if (host === 'youtube.com' || host === 'm.youtube.com') {
+        if (parsed.pathname === '/watch') {
+          return cleanVideoId(parsed.searchParams.get('v'));
+        }
+
+        const pathParts = parsed.pathname.split('/').filter(Boolean);
+        const embedIndex = pathParts.indexOf('embed');
+        if (embedIndex >= 0 && pathParts[embedIndex + 1]) {
+          return cleanVideoId(pathParts[embedIndex + 1]);
+        }
+      }
+
+      return null;
+    } catch (error) {
+      return null;
+    }
+  }
+
+  function getYouTubeThumbnailCandidates(videoId) {
+    if (!videoId) return [];
+
+    return [
+      `https://img.youtube.com/vi/${encodeURIComponent(videoId)}/maxresdefault.jpg`,
+      `https://img.youtube.com/vi/${encodeURIComponent(videoId)}/hqdefault.jpg`,
+      `https://img.youtube.com/vi/${encodeURIComponent(videoId)}/mqdefault.jpg`
+    ];
+  }
+
+  globalScope.YouTubeUtils = {
+    extractYouTubeVideoId,
+    getYouTubeThumbnailCandidates
+  };
+})(window);


### PR DESCRIPTION
### Motivation
- YouTube embed/watch/short links produce inconsistent preview thumbnails due to varying oEmbed/OG metadata and caching, causing some cards to show default thumbnails. 
- The goal is to deterministically derive thumbnails from the provided `videoUrl` values (kept as-is) and show consistent, accessible 16:9 images in the UI.

### Description
- Added `youtube-utils.js` which exposes `extractYouTubeVideoId(url)` that recognizes `youtube.com/embed/...`, `youtube.com/watch?v=...`, and `youtu.be/...` links (ignores query/hash params) and `getYouTubeThumbnailCandidates(videoId)` which returns `[maxresdefault,hqdefault,mqdefault]` URLs. 
- Loaded `youtube-utils.js` before `script.js` in `index.html` so runtime derivation is available without changing existing film objects. 
- Updated `script.js` to use the helper via `parseVideoId()` and `getThumbnailCandidates()` and to render each film card with an explicit 16:9 `<img>` wrapped in a clickable link to the watch URL (`https://www.youtube.com/watch?v=VIDEO_ID`), using the film `title` for accessible `alt` text. 
- Implemented ordered fallback logic on image `error` that advances through candidate thumbnails (`maxresdefault` → `hqdefault` → `mqdefault`) using `data-thumb-index` and `data-thumb-candidates` to avoid infinite loops, plus a short code comment explaining why direct thumbnail generation is used instead of relying on embed previews. 
- Adjusted `styles.css` selectors to support the new anchor wrapper and ensure the thumbnail keeps the existing `aspect-ratio: 16 / 9` sizing to prevent layout shift.

### Testing
- Ran `node --check script.js && node --check youtube-utils.js`, which completed successfully. 
- Executed a Node VM runtime check that called `extractYouTubeVideoId` against sample embed/watch/short/invalid URLs and verified correct ID extraction for valid YouTube formats. 
- Attempted a Playwright screenshot run to visually validate thumbnails, but the browser container failed to launch/locate elements in this environment, so visual capture did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69935f54fa6083328c5a9effab3f7b78)