### PR TITLE
Enhance film thumbnails with custom SVG play overlay

### DIFF
--- a/script.js
+++ b/script.js
@@ -554,7 +554,7 @@ function createVideoCard(film) {
           href="${film.watchUrl}"
           target="_blank"
           rel="noopener noreferrer"
-          aria-label="Watch ${film.title} on YouTube"
+          aria-label="Play video: ${escapeHtml(film.title)}"
         >
           <img
             src="${preferredThumbnail}"
@@ -564,8 +564,13 @@ function createVideoCard(film) {
             loading="lazy"
             decoding="async"
           />
-          <span class="video-overlay" aria-hidden="true">
-            <span class="play-icon">▶</span>
+          <span class="video-overlay">
+            <span class="play-button-overlay" role="img" aria-label="Play video">
+              <svg viewBox="0 0 64 64" aria-hidden="true" focusable="false">
+                <circle cx="32" cy="32" r="31" class="play-button-ring" />
+                <path d="M26 21.5L44.5 32L26 42.5V21.5Z" class="play-button-triangle" />
+              </svg>
+            </span>
           </span>
         </a>
       </div>

--- a/styles.css
+++ b/styles.css
@@ -243,10 +243,12 @@ h2 {
 
 .video-shell .video-thumb-link {
   display: block;
+  cursor: pointer;
 }
 
 .video-shell img {
   object-fit: cover;
+  transition: transform 260ms ease;
 }
 
 
@@ -261,18 +263,55 @@ h2 {
   inset: 0;
   display: grid;
   place-items: center;
-  background: linear-gradient(180deg, rgba(0, 0, 0, 0.15), rgba(0, 0, 0, 0.55));
+  background: linear-gradient(180deg, rgba(0, 0, 0, 0.08), rgba(0, 0, 0, 0.4));
+  transition: background 250ms ease;
 }
 
-.play-icon {
-  width: 64px;
-  height: 64px;
-  border-radius: 50%;
+.play-button-overlay {
+  width: clamp(52px, 16%, 78px);
+  aspect-ratio: 1;
+  border-radius: 999px;
   display: grid;
   place-items: center;
-  background: rgba(0, 0, 0, 0.72);
-  border: 1px solid rgba(255, 255, 255, 0.55);
-  font-size: 1.4rem;
+  background: rgba(10, 10, 10, 0.44);
+  border: 1px solid rgba(255, 255, 255, 0.34);
+  backdrop-filter: blur(3px);
+  box-shadow: 0 12px 34px rgba(0, 0, 0, 0.35);
+  transition: transform 250ms ease, opacity 250ms ease, box-shadow 250ms ease, background 250ms ease;
+  opacity: 0.95;
+}
+
+.play-button-overlay svg {
+  width: 100%;
+  height: 100%;
+}
+
+.play-button-ring {
+  fill: none;
+  stroke: rgba(240, 240, 240, 0.88);
+  stroke-width: 1.25;
+}
+
+.play-button-triangle {
+  fill: rgba(252, 252, 252, 0.96);
+}
+
+.video-thumb-link:hover .play-button-overlay,
+.video-thumb-link:focus-visible .play-button-overlay {
+  transform: scale(1.05);
+  opacity: 1;
+  background: rgba(8, 8, 8, 0.58);
+  box-shadow: 0 0 26px rgba(255, 255, 255, 0.19), 0 12px 34px rgba(0, 0, 0, 0.45);
+}
+
+.video-thumb-link:hover .video-overlay,
+.video-thumb-link:focus-visible .video-overlay {
+  background: linear-gradient(180deg, rgba(0, 0, 0, 0.03), rgba(0, 0, 0, 0.28));
+}
+
+.video-thumb-link:hover img,
+.video-thumb-link:focus-visible img {
+  transform: scale(1.02);
 }
 
 .film-meta {


### PR DESCRIPTION
### Motivation
- Replace the default/text-based YouTube play indicator with a modern, high-resolution play overlay that better matches the film-portfolio aesthetic. 
- Keep thumbnails clickable everywhere (no iframe/play UI reliance) and preserve accessibility and alt text for images.

### Description
- Replaced the inline text play glyph with an inline SVG play overlay in the generated video card markup and updated the link `aria-label` to `Play video: ...` while keeping the image `alt` intact (`script.js`).
- Added a reusable `.play-button-overlay` element and SVG (circle ring + play triangle) placed centered with absolute positioning inside `.video-overlay` (`script.js`).
- Updated styles (`styles.css`) to: show pointer cursor on the thumb link, add responsive sizing with `clamp()` and `aspect-ratio` for the overlay, subtle glassmorphism blur, off-white SVG colors, smooth hover/focus animations (scale, soft glow, thumbnail micro-zoom), and keep overlay non-interactive using `pointer-events: none` so link navigation is preserved.
- Ensured responsiveness and retina-quality by using inline SVG and responsive CSS units so the overlay scales on mobile and desktop.

### Testing
- Ran a syntax check with `node --check script.js`, which succeeded.
- Served the site locally with `python3 -m http.server 4173` and captured a Playwright visual screenshot of the page, confirming the overlay renders and hover/focus styles apply (visual capture artifact produced).
- No unit tests were present for these UI changes; the above static check and automated visual capture succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699360bc9e608332b4ec9aae7497a1ef)