### PR TITLE
Normalize YouTube IDs and fix embeds/routes to use internal `/films/:id` with robust thumbnails

### DIFF
--- a/youtube-utils.js
+++ b/youtube-utils.js
@@ -1,7 +1,12 @@
 (function attachYouTubeUtils(globalScope) {
+  function assertYouTubeId(id) {
+    return typeof id === 'string' && /^[A-Za-z0-9_-]{11}$/.test(id);
+  }
+
   function cleanVideoId(value) {
     if (!value) return null;
-    return value.split(/[?#]/)[0].trim() || null;
+    const cleanedValue = value.split(/[?#]/)[0].trim() || null;
+    return assertYouTubeId(cleanedValue) ? cleanedValue : null;
   }
 
   function extractYouTubeVideoId(url) {
@@ -33,10 +38,9 @@
   }
 
   function getYouTubeThumbnailCandidates(videoId) {
-    if (!videoId) return [];
+    if (!assertYouTubeId(videoId)) return [];
 
     return [
-      `https://img.youtube.com/vi/${encodeURIComponent(videoId)}/maxresdefault.jpg`,
       `https://img.youtube.com/vi/${encodeURIComponent(videoId)}/hqdefault.jpg`,
       `https://img.youtube.com/vi/${encodeURIComponent(videoId)}/mqdefault.jpg`,
       `https://img.youtube.com/vi/${encodeURIComponent(videoId)}/sddefault.jpg`,


### PR DESCRIPTION
### Motivation
- The site was broken by brittle runtime embeddability/probing logic and by deriving navigation/previews from `videoUrl` rather than a stable ID, causing inconsistent thumbnails and fallbacks (root cause: embeddability checks + weak ID parsing in `script.js`/`youtube-utils.js`).
- Cards must navigate to an internal Details page and the Details page must reliably render an iframe built only from a validated YouTube `videoId`.
- Thumbnails must be deterministic (only `img.youtube.com`) and must not cause infinite fallback loops or rerenders.
- Provide developer guardrails (validation warnings) and graceful UI for missing/invalid IDs.

### Description
- Added a stable 11-character `id` to each film entry and introduced `normalizeFilmData` plus an `assertYouTubeId(id)` helper to ensure `videoId` is validated and stored once at startup.  
- Removed fragile embeddability-probing and runtime YouTube API/Iframe API checks and stopped using `videoUrl` for routing/thumbnail/embed decisions; thumbnails now come deterministically from `img.youtube.com` via `getDeterministicThumbnailFallbacks`.  
- Details page iframe now builds src only from `videoId` using `https://www.youtube-nocookie.com/embed/${videoId}` and includes safe attributes: `allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"`, `allowFullScreen`, `referrerPolicy="strict-origin-when-cross-origin"`, and `loading="lazy"`.  
- Routing and links updated to use internal `/films/:id` while preserving legacy `/video/:id` parsing, and the Details UI gracefully shows `Video unavailable.` when a valid ID is not available.  
- Hardened `youtube-utils.js` to return only 11-char IDs and changed noisy optional-dependency logs from `console.error` to `console.warn` to reduce console noise.

### Testing
- Static checks: `node --check script.js` and `node --check youtube-utils.js` both succeeded.  
- Local server: served the site via `python3 -m http.server 4173` and exercised flows with Playwright automation that performed click-through and navigation tests.  
- Playwright validation confirmed: clicking a film card opens the internal route `http://.../films/<id>` and the Details overlay contains an iframe with src `https://www.youtube-nocookie.com/embed/<id>` and produced no console errors during the normal click-through flow (passed).  
- Direct `GET /films/<id>` on the static `http.server` returned 404 because the static server lacks SPA rewrite fallbacks (this is a deployment/static-server limitation, not an app-side routing failure); app-side route handling opens details correctly when the index page is served (observed in automated tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699370bb7e3c83328f193b02b504fde5)