### PR TITLE
Replace writing detail pages with PDF viewer

### DIFF
--- a/src/pages/writing-detail.js
+++ b/src/pages/writing-detail.js
@@ -9,8 +9,39 @@
       .replaceAll("'", '&#39;');
   }
 
+  function defaultPdfPath(item) {
+    return `/src/writings/${encodeURIComponent(item.slug)}.pdf`;
+  }
+
+  function pdfViewerConfig(item) {
+    const pdf = item.pdf && typeof item.pdf === 'object' ? item.pdf : {};
+    const src = item.pdfUrl || pdf.src || defaultPdfPath(item);
+    const title = pdf.title || item.pdfTitle || `${item.title} pdf`;
+    const downloadLabel = pdf.downloadLabel || item.pdfDownloadLabel || 'open pdf';
+    const note = pdf.note || item.pdfNote || 'place or replace this pdf in src/writings to update the viewer.';
+    return { src, title, downloadLabel, note };
+  }
+
+  function pdfUrl(src) {
+    if (/^(https?:)?\/\//i.test(src) || String(src).startsWith('data:')) return src;
+    const normalized = String(src || '').startsWith('/') ? src : `/${src}`;
+    return window.AppUtils.toUrl(normalized);
+  }
+
   function writingContentHtml(item) {
-    return `<div class="writing-detail-body">${escapeHtml(item.content)}</div>`;
+    const viewer = pdfViewerConfig(item);
+    const src = pdfUrl(viewer.src);
+    const safeTitle = escapeHtml(viewer.title);
+    return `<div class="pdf-viewer-shell">
+      <div class="pdf-viewer-toolbar">
+        <p>${escapeHtml(viewer.note)}</p>
+        <a class="quiet-btn pdf-viewer-action" href="${escapeHtml(src)}" target="_blank" rel="noopener noreferrer">${escapeHtml(viewer.downloadLabel)}</a>
+      </div>
+      <object class="pdf-viewer-frame" data="${escapeHtml(src)}" type="application/pdf" aria-label="${safeTitle}">
+        <iframe src="${escapeHtml(src)}" title="${safeTitle}" loading="lazy"></iframe>
+        <p>this browser cannot display the pdf inline. <a href="${escapeHtml(src)}" target="_blank" rel="noopener noreferrer">open it here</a>.</p>
+      </object>
+    </div>`;
   }
 
   function writingDetailView(slug) {

--- a/src/writings/README.md
+++ b/src/writings/README.md
@@ -1,0 +1,31 @@
+# PDF writing files
+
+Each writing detail page now renders a PDF viewer instead of inline prose.
+
+By default, the viewer looks for a PDF named after the writing slug:
+
+- `src/writings/afterthought.pdf`
+- `src/writings/a-b-c.pdf`
+- `src/writings/keep-calm-and-carry-on.pdf`
+- `src/writings/the-man-in-the-hole.pdf`
+- `src/writings/lull.pdf`
+- `src/writings/room-413.pdf`
+
+To customize an individual PDF, add a `pdf` object to the corresponding entry in `src/writings.js`:
+
+```js
+{
+  slug: "afterthought",
+  title: "Afterthought",
+  excerpt: "...",
+  year: 2026,
+  pdf: {
+    src: "/src/writings/afterthought.pdf",
+    title: "Afterthought screenplay PDF",
+    downloadLabel: "open afterthought",
+    note: "screenplay draft"
+  }
+}
+```
+
+Only `src` is needed when the PDF file name does not match the slug; the other fields customize viewer labels.

--- a/src/writings/a-b-c.pdf
+++ b/src/writings/a-b-c.pdf
@@ -1,0 +1,29 @@
+%PDF-1.4
+%
+1 0 obj << /Type /Catalog /Pages 2 0 R >> endobj
+2 0 obj << /Type /Pages /Kids [3 0 R] /Count 1 >> endobj
+3 0 obj << /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >> endobj
+4 0 obj << /Type /Font /Subtype /Type1 /BaseFont /Helvetica >> endobj
+5 0 obj << /Length 185 >> stream
+BT
+/F1 24 Tf
+72 740 Td
+(A and B and C) Tj
+/F1 12 Tf
+0 -24 Td () Tj
+0 -24 Td (Replace this file with your custom PDF.) Tj
+0 -24 Td (The writing detail page will display it inline.) Tj
+ET
+endstream endobj
+xref
+0 6
+0000000000 65535 f 
+0000000015 00000 n 
+0000000064 00000 n 
+0000000121 00000 n 
+0000000247 00000 n 
+0000000317 00000 n 
+trailer << /Size 6 /Root 1 0 R >>
+startxref
+553
+%%EOF

--- a/src/writings/afterthought.pdf
+++ b/src/writings/afterthought.pdf
@@ -1,0 +1,29 @@
+%PDF-1.4
+%
+1 0 obj << /Type /Catalog /Pages 2 0 R >> endobj
+2 0 obj << /Type /Pages /Kids [3 0 R] /Count 1 >> endobj
+3 0 obj << /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >> endobj
+4 0 obj << /Type /Font /Subtype /Type1 /BaseFont /Helvetica >> endobj
+5 0 obj << /Length 184 >> stream
+BT
+/F1 24 Tf
+72 740 Td
+(Afterthought) Tj
+/F1 12 Tf
+0 -24 Td () Tj
+0 -24 Td (Replace this file with your custom PDF.) Tj
+0 -24 Td (The writing detail page will display it inline.) Tj
+ET
+endstream endobj
+xref
+0 6
+0000000000 65535 f 
+0000000015 00000 n 
+0000000064 00000 n 
+0000000121 00000 n 
+0000000247 00000 n 
+0000000317 00000 n 
+trailer << /Size 6 /Root 1 0 R >>
+startxref
+552
+%%EOF

--- a/src/writings/keep-calm-and-carry-on.pdf
+++ b/src/writings/keep-calm-and-carry-on.pdf
@@ -1,0 +1,29 @@
+%PDF-1.4
+%
+1 0 obj << /Type /Catalog /Pages 2 0 R >> endobj
+2 0 obj << /Type /Pages /Kids [3 0 R] /Count 1 >> endobj
+3 0 obj << /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >> endobj
+4 0 obj << /Type /Font /Subtype /Type1 /BaseFont /Helvetica >> endobj
+5 0 obj << /Length 194 >> stream
+BT
+/F1 24 Tf
+72 740 Td
+(Keep Calm and Carry On) Tj
+/F1 12 Tf
+0 -24 Td () Tj
+0 -24 Td (Replace this file with your custom PDF.) Tj
+0 -24 Td (The writing detail page will display it inline.) Tj
+ET
+endstream endobj
+xref
+0 6
+0000000000 65535 f 
+0000000015 00000 n 
+0000000064 00000 n 
+0000000121 00000 n 
+0000000247 00000 n 
+0000000317 00000 n 
+trailer << /Size 6 /Root 1 0 R >>
+startxref
+562
+%%EOF

--- a/src/writings/lull.pdf
+++ b/src/writings/lull.pdf
@@ -1,0 +1,29 @@
+%PDF-1.4
+%
+1 0 obj << /Type /Catalog /Pages 2 0 R >> endobj
+2 0 obj << /Type /Pages /Kids [3 0 R] /Count 1 >> endobj
+3 0 obj << /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >> endobj
+4 0 obj << /Type /Font /Subtype /Type1 /BaseFont /Helvetica >> endobj
+5 0 obj << /Length 176 >> stream
+BT
+/F1 24 Tf
+72 740 Td
+(Lull) Tj
+/F1 12 Tf
+0 -24 Td () Tj
+0 -24 Td (Replace this file with your custom PDF.) Tj
+0 -24 Td (The writing detail page will display it inline.) Tj
+ET
+endstream endobj
+xref
+0 6
+0000000000 65535 f 
+0000000015 00000 n 
+0000000064 00000 n 
+0000000121 00000 n 
+0000000247 00000 n 
+0000000317 00000 n 
+trailer << /Size 6 /Root 1 0 R >>
+startxref
+544
+%%EOF

--- a/src/writings/room-413.pdf
+++ b/src/writings/room-413.pdf
@@ -1,0 +1,29 @@
+%PDF-1.4
+%
+1 0 obj << /Type /Catalog /Pages 2 0 R >> endobj
+2 0 obj << /Type /Pages /Kids [3 0 R] /Count 1 >> endobj
+3 0 obj << /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >> endobj
+4 0 obj << /Type /Font /Subtype /Type1 /BaseFont /Helvetica >> endobj
+5 0 obj << /Length 180 >> stream
+BT
+/F1 24 Tf
+72 740 Td
+(Room 413) Tj
+/F1 12 Tf
+0 -24 Td () Tj
+0 -24 Td (Replace this file with your custom PDF.) Tj
+0 -24 Td (The writing detail page will display it inline.) Tj
+ET
+endstream endobj
+xref
+0 6
+0000000000 65535 f 
+0000000015 00000 n 
+0000000064 00000 n 
+0000000121 00000 n 
+0000000247 00000 n 
+0000000317 00000 n 
+trailer << /Size 6 /Root 1 0 R >>
+startxref
+548
+%%EOF

--- a/src/writings/the-man-in-the-hole.pdf
+++ b/src/writings/the-man-in-the-hole.pdf
@@ -1,0 +1,29 @@
+%PDF-1.4
+%
+1 0 obj << /Type /Catalog /Pages 2 0 R >> endobj
+2 0 obj << /Type /Pages /Kids [3 0 R] /Count 1 >> endobj
+3 0 obj << /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >> endobj
+4 0 obj << /Type /Font /Subtype /Type1 /BaseFont /Helvetica >> endobj
+5 0 obj << /Length 191 >> stream
+BT
+/F1 24 Tf
+72 740 Td
+(The Man in The Hole) Tj
+/F1 12 Tf
+0 -24 Td () Tj
+0 -24 Td (Replace this file with your custom PDF.) Tj
+0 -24 Td (The writing detail page will display it inline.) Tj
+ET
+endstream endobj
+xref
+0 6
+0000000000 65535 f 
+0000000015 00000 n 
+0000000064 00000 n 
+0000000121 00000 n 
+0000000247 00000 n 
+0000000317 00000 n 
+trailer << /Size 6 /Root 1 0 R >>
+startxref
+559
+%%EOF

--- a/styles.css
+++ b/styles.css
@@ -986,20 +986,56 @@ main {
 }
 
 .writing-detail article {
-  max-width: 68ch;
+  width: min(100%, 980px);
   border: 1px solid var(--line);
   border-radius: 12px;
   padding: clamp(1rem, 2.3vw, 1.6rem);
   background: linear-gradient(180deg, rgba(20, 22, 27, 0.94), rgba(14, 15, 18, 0.95));
 }
 
-.writing-detail article .writing-detail-body {
+.pdf-viewer-shell {
+  display: grid;
+  gap: 1rem;
+}
+
+.pdf-viewer-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--line);
+}
+
+.pdf-viewer-toolbar p {
   margin: 0;
-  line-height: 1.8;
+  max-width: 62ch;
   color: var(--muted);
-  white-space: pre-wrap;
-  overflow-wrap: anywhere;
-  tab-size: 2;
+}
+
+.pdf-viewer-action {
+  flex: 0 0 auto;
+}
+
+.pdf-viewer-frame {
+  display: block;
+  width: 100%;
+  min-height: clamp(520px, 78vh, 880px);
+  border: 1px solid rgba(255, 226, 196, 0.16);
+  border-radius: 10px;
+  overflow: hidden;
+  background: rgba(7, 8, 10, 0.62);
+}
+
+.pdf-viewer-frame iframe {
+  width: 100%;
+  min-height: clamp(520px, 78vh, 880px);
+  border: 0;
+}
+
+.pdf-viewer-frame p {
+  margin: 1rem;
 }
 
 .page--writing-detail *,


### PR DESCRIPTION
### Motivation
- Replace inline prose rendering on writing detail pages with an embeddable PDF viewer so each writing can be presented/updated as a PDF asset and customized per-entry.

### Description
- Implemented a configurable PDF viewer in `src/pages/writing-detail.js` which defaults to `/src/writings/<slug>.pdf` and supports per-entry overrides via a `pdf` object (`src`, `title`, `downloadLabel`, `note`).
- Viewer renders an accessible `<object>` with an `<iframe>` fallback and preserves the existing title/excerpt/year header layout inside the article area.
- Added responsive viewer styling and layout in `styles.css` (`.pdf-viewer-shell`, toolbar, `.pdf-viewer-frame`) and adjusted writing article sizing.
- Added `src/writings/README.md` and placeholder `src/writings/*.pdf` files for current writings so previews work out of the box and to document how to replace/customize PDFs.

### Testing
- `node --check src/pages/writing-detail.js` succeeded without syntax errors.
- `node --check script.js` succeeded without syntax errors.
- A Python validation script checked each generated `src/writings/*.pdf` for a `%PDF-` header and `%%EOF` marker and all files passed validation.
- A temporary `python3 -m http.server` was started and `curl -I http://127.0.0.1:8000/src/writings/afterthought.pdf` returned `200 OK` confirming the PDF is served correctly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5180e28ab08332b65fd51d2cd08553)