### PR TITLE
Add in-browser PDF previews for writing detail pages

### DIFF
--- a/script.js
+++ b/script.js
@@ -5,6 +5,8 @@ const WRITINGS = Array.isArray(window.WRITINGS_DATA) ? window.WRITINGS_DATA : []
 const LIST_CTA_LABEL = 'show more';
 const YOUTUBE_ID_REGEX = /^[A-Za-z0-9_-]{11}$/;
 const EMBED_LOAD_TIMEOUT_MS = 3200;
+const PDFJS_MODULE_URL = 'https://cdn.jsdelivr.net/npm/pdfjs-dist@4.10.38/build/pdf.min.mjs';
+const PDFJS_WORKER_URL = 'https://cdn.jsdelivr.net/npm/pdfjs-dist@4.10.38/build/pdf.worker.min.mjs';
 const SESSION_LOAD_KEY = 'andalagy:load-overlay-played';
 const INTRO_TIMINGS = {
   standard: {
@@ -97,6 +99,7 @@ let floatingTextNearTimer = 0;
 let slateClapTimer = 0;
 let routeEnterCleanupTimer = 0;
 let isSlateCollapsed = false;
+let pdfJsModulePromise = null;
 const animationSeenKeys = new Set();
 const animationRegistry = {
   hasSeen(key) {
@@ -601,6 +604,7 @@ function bindDynamicInteractions() {
   applyScrollDissolve();
   useRevealOnce();
   initYouTubeThumbnailFallbacks();
+  initPdfPreviews();
 
   const slate = document.querySelector('[data-slate]');
   slate?.addEventListener('click', handleSlateInteract);
@@ -616,6 +620,66 @@ function bindDynamicInteractions() {
   setupHoverDust();
 
   setupFilmEmbedFallback();
+}
+
+function loadPdfJsModule() {
+  if (!pdfJsModulePromise) {
+    pdfJsModulePromise = import(PDFJS_MODULE_URL).then((pdfjsLib) => {
+      pdfjsLib.GlobalWorkerOptions.workerSrc = PDFJS_WORKER_URL;
+      return pdfjsLib;
+    });
+  }
+  return pdfJsModulePromise;
+}
+
+function setPdfPreviewState(preview, state) {
+  preview.dataset.pdfState = state;
+}
+
+function renderPdfPreview(preview, pdfjsLib) {
+  const canvas = preview.querySelector('[data-pdf-canvas]');
+  const link = preview.querySelector('.pdf-document-link');
+  const src = preview.dataset.pdfSrc;
+  if (!canvas || !link || !src) {
+    setPdfPreviewState(preview, 'fallback');
+    return Promise.resolve();
+  }
+
+  return pdfjsLib.getDocument(src).promise
+    .then((pdf) => pdf.getPage(1))
+    .then((page) => {
+      const baseViewport = page.getViewport({ scale: 1 });
+      const availableWidth = Math.min(580, Math.max(240, link.clientWidth - 48));
+      const scale = Math.min(1.5, availableWidth / baseViewport.width);
+      const viewport = page.getViewport({ scale });
+      const outputScale = Math.max(1, window.devicePixelRatio || 1);
+      const context = canvas.getContext('2d');
+
+      if (!context) throw new Error('canvas unavailable');
+
+      canvas.width = Math.floor(viewport.width * outputScale);
+      canvas.height = Math.floor(viewport.height * outputScale);
+      canvas.style.width = `${Math.floor(viewport.width)}px`;
+      canvas.style.height = `${Math.floor(viewport.height)}px`;
+
+      return page.render({
+        canvasContext: context,
+        viewport,
+        transform: outputScale === 1 ? null : [outputScale, 0, 0, outputScale, 0, 0]
+      }).promise;
+    })
+    .then(() => setPdfPreviewState(preview, 'ready'))
+    .catch(() => setPdfPreviewState(preview, 'fallback'));
+}
+
+function initPdfPreviews() {
+  const previews = [...document.querySelectorAll('[data-pdf-preview]')];
+  if (!previews.length) return;
+
+  previews.forEach((preview) => setPdfPreviewState(preview, 'loading'));
+  loadPdfJsModule()
+    .then((pdfjsLib) => Promise.all(previews.map((preview) => renderPdfPreview(preview, pdfjsLib))))
+    .catch(() => previews.forEach((preview) => setPdfPreviewState(preview, 'fallback')));
 }
 
 function initYouTubeThumbnailFallbacks() {

--- a/src/pages/writing-detail.js
+++ b/src/pages/writing-detail.js
@@ -9,8 +9,39 @@
       .replaceAll("'", '&#39;');
   }
 
+  function defaultPdfPath(item) {
+    return `/src/writings/${encodeURIComponent(item.slug)}.pdf`;
+  }
+
+  function pdfDocumentConfig(item) {
+    const pdf = item.pdf && typeof item.pdf === 'object' ? item.pdf : {};
+    const src = item.pdfUrl || pdf.src || defaultPdfPath(item);
+    const downloadLabel = pdf.downloadLabel || item.pdfDownloadLabel || 'download pdf';
+    return { src, downloadLabel };
+  }
+
+  function pdfUrl(src) {
+    if (/^(https?:)?\/\//i.test(src) || String(src).startsWith('data:')) return src;
+    const normalized = String(src || '').startsWith('/') ? src : `/${src}`;
+    return window.AppUtils.toUrl(normalized);
+  }
+
   function writingContentHtml(item) {
-    return `<div class="writing-detail-body">${escapeHtml(item.content)}</div>`;
+    const pdf = pdfDocumentConfig(item);
+    const src = pdfUrl(pdf.src);
+    const title = window.AppUtils.lower(item.title);
+    const accessibleLabel = `open ${title} pdf`;
+    const downloadLabel = window.AppUtils.lower(pdf.downloadLabel);
+    return `<figure class="pdf-document-preview" data-pdf-preview data-pdf-src="${escapeHtml(src)}">
+      <a class="pdf-document-link" href="${escapeHtml(src)}" target="_blank" rel="noopener noreferrer" aria-label="${escapeHtml(accessibleLabel)}">
+        <canvas class="pdf-document-canvas" data-pdf-canvas aria-hidden="true"></canvas>
+        <span class="pdf-document-placeholder" data-pdf-placeholder aria-hidden="true"></span>
+        <span class="pdf-document-open" aria-hidden="true">open pdf</span>
+      </a>
+      <figcaption>
+        <a class="pdf-document-download" href="${escapeHtml(src)}" download>${escapeHtml(downloadLabel)}</a>
+      </figcaption>
+    </figure>`;
   }
 
   function writingDetailView(slug) {

--- a/src/writings/README.md
+++ b/src/writings/README.md
@@ -1,0 +1,29 @@
+# PDF writing files
+
+Each writing detail page renders the first page of its PDF directly in the browser. Clicking the preview opens the original PDF in a new tab, and a small download link remains below it. No separate preview image is required.
+
+By default, the page looks for a PDF named after the writing slug:
+
+- `src/writings/afterthought.pdf`
+- `src/writings/a-b-c.pdf`
+- `src/writings/keep-calm-and-carry-on.pdf`
+- `src/writings/the-man-in-the-hole.pdf`
+- `src/writings/lull.pdf`
+- `src/writings/room-413.pdf`
+
+To customize an individual PDF, add a `pdf` object to the corresponding entry in `src/writings.js`:
+
+```js
+{
+  slug: "afterthought",
+  title: "Afterthought",
+  excerpt: "...",
+  year: 2026,
+  pdf: {
+    src: "/src/writings/afterthought.pdf",
+    downloadLabel: "download afterthought"
+  }
+}
+```
+
+Set `src` when the PDF file name does not match the slug, and use `downloadLabel` to customize the understated link below the preview.

--- a/src/writings/a-b-c.pdf
+++ b/src/writings/a-b-c.pdf
@@ -1,0 +1,29 @@
+%PDF-1.4
+%
+1 0 obj << /Type /Catalog /Pages 2 0 R >> endobj
+2 0 obj << /Type /Pages /Kids [3 0 R] /Count 1 >> endobj
+3 0 obj << /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >> endobj
+4 0 obj << /Type /Font /Subtype /Type1 /BaseFont /Helvetica >> endobj
+5 0 obj << /Length 174 >> stream
+BT
+/F1 24 Tf
+72 740 Td
+(A and B and C) Tj
+/F1 12 Tf
+0 -24 Td () Tj
+0 -24 Td (Replace this file with your PDF.) Tj
+0 -24 Td (The writing detail page links to this file.) Tj
+ET
+endstream endobj
+xref
+0 6
+0000000000 65535 f 
+0000000015 00000 n 
+0000000064 00000 n 
+0000000121 00000 n 
+0000000247 00000 n 
+0000000317 00000 n 
+trailer << /Size 6 /Root 1 0 R >>
+startxref
+542
+%%EOF

--- a/src/writings/afterthought.pdf
+++ b/src/writings/afterthought.pdf
@@ -1,0 +1,29 @@
+%PDF-1.4
+%
+1 0 obj << /Type /Catalog /Pages 2 0 R >> endobj
+2 0 obj << /Type /Pages /Kids [3 0 R] /Count 1 >> endobj
+3 0 obj << /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >> endobj
+4 0 obj << /Type /Font /Subtype /Type1 /BaseFont /Helvetica >> endobj
+5 0 obj << /Length 173 >> stream
+BT
+/F1 24 Tf
+72 740 Td
+(Afterthought) Tj
+/F1 12 Tf
+0 -24 Td () Tj
+0 -24 Td (Replace this file with your PDF.) Tj
+0 -24 Td (The writing detail page links to this file.) Tj
+ET
+endstream endobj
+xref
+0 6
+0000000000 65535 f 
+0000000015 00000 n 
+0000000064 00000 n 
+0000000121 00000 n 
+0000000247 00000 n 
+0000000317 00000 n 
+trailer << /Size 6 /Root 1 0 R >>
+startxref
+541
+%%EOF

--- a/src/writings/keep-calm-and-carry-on.pdf
+++ b/src/writings/keep-calm-and-carry-on.pdf
@@ -1,0 +1,29 @@
+%PDF-1.4
+%
+1 0 obj << /Type /Catalog /Pages 2 0 R >> endobj
+2 0 obj << /Type /Pages /Kids [3 0 R] /Count 1 >> endobj
+3 0 obj << /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >> endobj
+4 0 obj << /Type /Font /Subtype /Type1 /BaseFont /Helvetica >> endobj
+5 0 obj << /Length 183 >> stream
+BT
+/F1 24 Tf
+72 740 Td
+(Keep Calm and Carry On) Tj
+/F1 12 Tf
+0 -24 Td () Tj
+0 -24 Td (Replace this file with your PDF.) Tj
+0 -24 Td (The writing detail page links to this file.) Tj
+ET
+endstream endobj
+xref
+0 6
+0000000000 65535 f 
+0000000015 00000 n 
+0000000064 00000 n 
+0000000121 00000 n 
+0000000247 00000 n 
+0000000317 00000 n 
+trailer << /Size 6 /Root 1 0 R >>
+startxref
+551
+%%EOF

--- a/src/writings/lull.pdf
+++ b/src/writings/lull.pdf
@@ -1,0 +1,29 @@
+%PDF-1.4
+%
+1 0 obj << /Type /Catalog /Pages 2 0 R >> endobj
+2 0 obj << /Type /Pages /Kids [3 0 R] /Count 1 >> endobj
+3 0 obj << /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >> endobj
+4 0 obj << /Type /Font /Subtype /Type1 /BaseFont /Helvetica >> endobj
+5 0 obj << /Length 165 >> stream
+BT
+/F1 24 Tf
+72 740 Td
+(Lull) Tj
+/F1 12 Tf
+0 -24 Td () Tj
+0 -24 Td (Replace this file with your PDF.) Tj
+0 -24 Td (The writing detail page links to this file.) Tj
+ET
+endstream endobj
+xref
+0 6
+0000000000 65535 f 
+0000000015 00000 n 
+0000000064 00000 n 
+0000000121 00000 n 
+0000000247 00000 n 
+0000000317 00000 n 
+trailer << /Size 6 /Root 1 0 R >>
+startxref
+533
+%%EOF

--- a/src/writings/room-413.pdf
+++ b/src/writings/room-413.pdf
@@ -1,0 +1,29 @@
+%PDF-1.4
+%
+1 0 obj << /Type /Catalog /Pages 2 0 R >> endobj
+2 0 obj << /Type /Pages /Kids [3 0 R] /Count 1 >> endobj
+3 0 obj << /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >> endobj
+4 0 obj << /Type /Font /Subtype /Type1 /BaseFont /Helvetica >> endobj
+5 0 obj << /Length 169 >> stream
+BT
+/F1 24 Tf
+72 740 Td
+(Room 413) Tj
+/F1 12 Tf
+0 -24 Td () Tj
+0 -24 Td (Replace this file with your PDF.) Tj
+0 -24 Td (The writing detail page links to this file.) Tj
+ET
+endstream endobj
+xref
+0 6
+0000000000 65535 f 
+0000000015 00000 n 
+0000000064 00000 n 
+0000000121 00000 n 
+0000000247 00000 n 
+0000000317 00000 n 
+trailer << /Size 6 /Root 1 0 R >>
+startxref
+537
+%%EOF

--- a/src/writings/the-man-in-the-hole.pdf
+++ b/src/writings/the-man-in-the-hole.pdf
@@ -1,0 +1,29 @@
+%PDF-1.4
+%
+1 0 obj << /Type /Catalog /Pages 2 0 R >> endobj
+2 0 obj << /Type /Pages /Kids [3 0 R] /Count 1 >> endobj
+3 0 obj << /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >> endobj
+4 0 obj << /Type /Font /Subtype /Type1 /BaseFont /Helvetica >> endobj
+5 0 obj << /Length 180 >> stream
+BT
+/F1 24 Tf
+72 740 Td
+(The Man in The Hole) Tj
+/F1 12 Tf
+0 -24 Td () Tj
+0 -24 Td (Replace this file with your PDF.) Tj
+0 -24 Td (The writing detail page links to this file.) Tj
+ET
+endstream endobj
+xref
+0 6
+0000000000 65535 f 
+0000000015 00000 n 
+0000000064 00000 n 
+0000000121 00000 n 
+0000000247 00000 n 
+0000000317 00000 n 
+trailer << /Size 6 /Root 1 0 R >>
+startxref
+548
+%%EOF

--- a/styles.css
+++ b/styles.css
@@ -986,20 +986,151 @@ main {
 }
 
 .writing-detail article {
-  max-width: 68ch;
-  border: 1px solid var(--line);
-  border-radius: 12px;
-  padding: clamp(1rem, 2.3vw, 1.6rem);
-  background: linear-gradient(180deg, rgba(20, 22, 27, 0.94), rgba(14, 15, 18, 0.95));
+  width: min(100%, 760px);
 }
 
-.writing-detail article .writing-detail-body {
+.pdf-document-preview {
+  width: 100%;
   margin: 0;
-  line-height: 1.8;
+}
+
+.pdf-document-link {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  min-height: clamp(460px, 68vw, 840px);
+  padding: clamp(1.2rem, 4vw, 2.8rem);
+  overflow: hidden;
+  border: 1px solid rgba(255, 226, 196, 0.11);
+  border-radius: 22px;
+  background:
+    radial-gradient(circle at 50% 3%, rgba(255, 226, 196, 0.1), transparent 42%),
+    rgba(8, 9, 12, 0.44);
+  box-shadow: 0 28px 90px rgba(0, 0, 0, 0.3);
+}
+
+.pdf-document-link::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(180deg, transparent 68%, rgba(7, 8, 11, 0.18));
+  pointer-events: none;
+}
+
+.pdf-document-canvas,
+.pdf-document-placeholder {
+  display: block;
+  width: min(100%, 580px);
+  aspect-ratio: 612 / 792;
+  object-fit: contain;
+  border-radius: 7px;
+  background: #f7f3ec;
+  box-shadow: 0 20px 64px rgba(0, 0, 0, 0.42), 0 0 0 1px rgba(255, 255, 255, 0.12);
+}
+
+.pdf-document-canvas {
+  position: relative;
+  z-index: 1;
+  filter: brightness(0.96) saturate(0.88);
+}
+
+.pdf-document-placeholder {
+  position: absolute;
+  top: clamp(1.2rem, 4vw, 2.8rem);
+  right: 0;
+  left: 0;
+  width: min(calc(100% - clamp(2.4rem, 8vw, 5.6rem)), 580px);
+  margin: 0 auto;
+  background:
+    linear-gradient(90deg, transparent 0 12%, rgba(53, 50, 46, 0.12) 12% 88%, transparent 88%) 50% 24% / 100% 1px no-repeat,
+    linear-gradient(90deg, transparent 0 12%, rgba(53, 50, 46, 0.1) 12% 76%, transparent 76%) 50% 31% / 100% 1px no-repeat,
+    linear-gradient(90deg, transparent 0 12%, rgba(53, 50, 46, 0.1) 12% 84%, transparent 84%) 50% 38% / 100% 1px no-repeat,
+    linear-gradient(180deg, #f6f1e9, #eee8df);
+  opacity: 0.78;
+}
+
+.pdf-document-preview[data-pdf-state='ready'] .pdf-document-placeholder {
+  display: none;
+}
+
+.pdf-document-preview[data-pdf-state='loading'] .pdf-document-canvas {
+  opacity: 0;
+}
+
+.pdf-document-preview[data-pdf-state='fallback'] .pdf-document-canvas {
+  display: none;
+}
+
+.pdf-document-preview[data-pdf-state='fallback'] .pdf-document-placeholder {
+  opacity: 0.7;
+}
+
+.pdf-document-open {
+  position: absolute;
+  right: clamp(1.8rem, 5vw, 3.8rem);
+  bottom: clamp(1.8rem, 5vw, 3.8rem);
+  z-index: 1;
+  padding: 0.48rem 0.72rem;
+  border-radius: 999px;
+  color: rgba(247, 240, 231, 0.84);
+  background: rgba(10, 11, 14, 0.74);
+  backdrop-filter: blur(9px);
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  opacity: 0;
+}
+
+.pdf-document-link:hover .pdf-document-canvas,
+.pdf-document-link:focus-visible .pdf-document-canvas {
+  filter: brightness(1) saturate(0.94);
+}
+
+.pdf-document-link:hover .pdf-document-open,
+.pdf-document-link:focus-visible .pdf-document-open {
+  opacity: 1;
+}
+
+.pdf-document-link:focus-visible {
+  outline: 2px solid rgba(255, 232, 207, 0.72);
+  outline-offset: 4px;
+}
+
+.pdf-document-preview figcaption {
+  margin-top: 0.8rem;
+  text-align: right;
+}
+
+.pdf-document-download {
   color: var(--muted);
-  white-space: pre-wrap;
-  overflow-wrap: anywhere;
-  tab-size: 2;
+  font-size: 0.76rem;
+  letter-spacing: 0.06em;
+  text-decoration: none;
+}
+
+.pdf-document-download:hover,
+.pdf-document-download:focus-visible {
+  color: var(--text);
+}
+
+.pdf-document-download:focus-visible {
+  outline: 1px solid rgba(255, 232, 207, 0.72);
+  outline-offset: 4px;
+}
+
+@media (max-width: 720px) {
+  .pdf-document-link {
+    padding: 1rem;
+    border-radius: 17px;
+  }
+
+  .pdf-document-open {
+    right: 1.6rem;
+    bottom: 1.6rem;
+    opacity: 1;
+  }
 }
 
 .page--writing-detail *,


### PR DESCRIPTION
### Motivation
- Provide inline previews of writing PDFs on detail pages so the first page renders directly in the browser and users can open or download the original PDF without separate preview images.

### Description
- Added dynamic PDF rendering using a CDN-hosted `pdfjs-dist` module and worker with `loadPdfJsModule`, `renderPdfPreview`, and `initPdfPreviews` hooks in `script.js`, plus state management via `data-pdf-state`.
- Updated the writing detail renderer in `src/pages/writing-detail.js` to output a semantic preview figure with `data-pdf-preview`, a linked `canvas` for the rendered first page, and a download link, and added helpers `pdfDocumentConfig`, `pdfUrl`, and `defaultPdfPath` to resolve PDF sources and labels.
- Introduced CSS rules in `styles.css` for the PDF preview layout, canvas/placeholder styling, accessibility/focus states, download link styling, and responsive adjustments.
- Added `src/writings/README.md` documenting the default PDF naming and per-entry `pdf` configuration, and included example placeholder PDF files under `src/writings/`.

### Testing
- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5180e28ab08332b65fd51d2cd08553)