### PR TITLE
Replace the public writings area with scripts

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
         shortcut.setAttribute("href", iconHref);
       })();
     </script>
-    <meta name="description" content="andrew yan films and writings" />
+    <meta name="description" content="andrew yan films and scripts" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -104,7 +104,7 @@
       <nav class="site-nav" aria-label="main navigation">
         <a href="./" data-link="/" data-anim-key="global:nav:home" data-reveal="link">home</a>
         <a href="./films" data-link="/films" data-anim-key="global:nav:films" data-reveal="link">films</a>
-        <a href="./writings" data-link="/writings" data-anim-key="global:nav:writings" data-reveal="link">writings</a>
+        <a href="./scripts" data-link="/scripts" data-anim-key="global:nav:scripts" data-reveal="link">scripts</a>
         <a href="./#about" data-about-link data-anim-key="global:nav:about" data-reveal="link">about</a>
       </nav>
     </header>
@@ -113,11 +113,11 @@
 
     <script defer src="./youtube-utils.js"></script>
     <script defer src="./src/films.js"></script>
-    <script type="module" defer src="./src/writings.js"></script>
+    <script defer src="./src/scripts.js"></script>
     <script defer src="./src/pages/films.js"></script>
     <script defer src="./src/pages/film-detail.js"></script>
-    <script defer src="./src/pages/writings.js"></script>
-    <script defer src="./src/pages/writing-detail.js"></script>
+    <script defer src="./src/pages/scripts.js"></script>
+    <script defer src="./src/pages/script-detail.js"></script>
     <script defer src="./script.js"></script>
   </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,7 +1,7 @@
-//animation renders & renders film & writing pages
+// animation renders film and script pages
 const APP_BASE_PATH = typeof window.__APP_BASE_PATH__ === 'string' ? window.__APP_BASE_PATH__ : detectBasePath();
 const FILMS = Array.isArray(window.FILMS_DATA) ? window.FILMS_DATA : [];
-const WRITINGS = Array.isArray(window.WRITINGS_DATA) ? window.WRITINGS_DATA : [];
+const SCRIPTS = Array.isArray(window.SCRIPTS_DATA) ? window.SCRIPTS_DATA : [];
 const LIST_CTA_LABEL = 'show more';
 const YOUTUBE_ID_REGEX = /^[A-Za-z0-9_-]{11}$/;
 const EMBED_LOAD_TIMEOUT_MS = 3200;
@@ -138,7 +138,7 @@ function detectBasePath(pathname = window.location.pathname) {
     .split('/')
     .filter(Boolean);
   const first = segments[0] || '';
-  if (!first || first === '404.html' || first === 'index.html' || first === 'films' || first === 'writings') {
+  if (!first || first === '404.html' || first === 'index.html' || first === 'films' || first === 'scripts') {
     return '';
   }
 
@@ -163,8 +163,9 @@ function routeFromLocation() {
   if (path === '/') return { page: 'home' };
   if (path === '/films') return { page: 'films' };
   if (path.startsWith('/films/')) return { page: 'film', id: decodeURIComponent(path.split('/')[2] || '') };
-  if (path === '/writings') return { page: 'writings' };
-  if (path.startsWith('/writings/')) return { page: 'writing', slug: decodeURIComponent(path.split('/')[2] || '') };
+  if (path === '/scripts') return { page: 'scripts' };
+  if (path.startsWith('/scripts/')) return { page: 'script', slug: decodeURIComponent(path.split('/')[2] || '') };
+  if (path === '/writings' || path.startsWith('/writings/')) return { page: 'home', redirectToHome: true };
   return { page: 'home' };
 }
 
@@ -296,42 +297,22 @@ function filmCard(film, index = 0) {
 
 window.APP_DATA = {
   films: FILMS,
-  writings: WRITINGS
+  scripts: SCRIPTS
 };
 
-function writingDetailPath(slug) {
-  return `/writings/${encodeURIComponent(slug)}`;
+function scriptDetailPath(slug) {
+  return `/scripts/${encodeURIComponent(slug)}`;
 }
 
-const WRITINGS_HERO_IMAGE =
-  'linear-gradient(180deg, rgba(18, 19, 23, 0.75), rgba(10, 10, 13, 0.95))';
-
-function writingTitleSizeClass(title = '') {
-  const length = String(title || '').trim().length;
-  if (length > 40) return 'title--xs';
-  if (length > 26) return 'title--sm';
-  return 'title--lg';
-}
-
-function writingCard(item, index = 0) {
-  const writingPath = writingDetailPath(item.slug);
-  const sliceIndexDesktop = ((index % 4) + 4) % 4;
-  const sliceIndexTablet = ((index % 2) + 2) % 2;
-  const coverImage = item.cover || item.coverImage || WRITINGS_HERO_IMAGE;
-  const mediaMarkup = `<div class="writing-composite-cover" aria-hidden="true" style="--slice-index-4:${sliceIndexDesktop};--slice-index-2:${sliceIndexTablet};--writings-hero-image:${coverImage};">
-      <span class="writing-haze"></span>
-    </div>`;
-
+function scriptCard(item, index = 0) {
+  const mediaMarkup = `<div class="script-cover" aria-hidden="true"><span class="script-haze"></span></div>`;
   return workCard({
-    href: writingPath,
+    href: scriptDetailPath(item.slug),
     title: item.title,
-    description: item.excerpt,
     mediaMarkup,
-    cardClass: 'writing-card',
-    titleClass: writingTitleSizeClass(item.title),
+    cardClass: 'script-card',
     titleInTile: true,
-    subtitleClass: 'writing-excerpt',
-    animKey: `writings:card:${item.slug}`,
+    animKey: `scripts:card:${item.slug}`,
     staggerIndex: index
   });
 }
@@ -368,7 +349,7 @@ function aboutBlock() {
 
 function homeView() {
   const shown = FILMS.slice(0, 4);
-  const shownWritings = WRITINGS.slice(0, 4);
+  const shownScripts = SCRIPTS.slice(0, 4);
   return `<section class="slate-wrap${isSlateCollapsed ? ' is-collapsed' : ''}" id="slate" data-slate-wrap data-anim-key="home:slate:wrap" data-reveal="section">
       <article class="slate" data-slate data-anim-key="home:slate:hero" data-reveal="hero">
         <span class="slate-glow" aria-hidden="true"></span>
@@ -388,15 +369,15 @@ function homeView() {
         <a class="quiet-btn section-cta" href="${toUrl('/films')}" data-link="/films" data-anim-key="home:films:cta" data-reveal="link">${LIST_CTA_LABEL} →</a>
       </div>
     </section>
-    <section class="home-writings" data-anim-key="home:writings:section" data-reveal="section">
+    <section class="home-scripts" data-anim-key="home:scripts:section" data-reveal="section">
       <div class="heading-row">
-        <h2 data-breath-heading data-anim-key="home:writings:heading" data-reveal="heading">writings</h2>
+        <h2 data-breath-heading data-anim-key="home:scripts:heading" data-reveal="heading">scripts</h2>
       </div>
-      <div class="writing-grid" data-anim-key="home:writings:grid" data-reveal="section">
-        ${shownWritings.map(writingCard).join('')}
+      <div class="script-grid" data-anim-key="home:scripts:grid" data-reveal="section">
+        ${shownScripts.map(scriptCard).join('')}
       </div>
       <div class="section-cta-row">
-        <a class="quiet-btn section-cta" href="${toUrl('/writings')}" data-link="/writings" data-anim-key="home:writings:cta" data-reveal="link">${LIST_CTA_LABEL} →</a>
+        <a class="quiet-btn section-cta" href="${toUrl('/scripts')}" data-link="/scripts" data-anim-key="home:scripts:cta" data-reveal="link">${LIST_CTA_LABEL} →</a>
       </div>
     </section>
     ${aboutBlock()}`;
@@ -422,7 +403,7 @@ window.AppUtils = {
   buildEmbedSrc,
   filmFallbackView,
   filmCard,
-  writingCard,
+  scriptCard,
   logDev
 };
 
@@ -431,6 +412,7 @@ async function render(options = {}) {
   const currentToken = ++routeTransitionToken;
   if (!app) return;
   const route = routeFromLocation();
+  if (route.redirectToHome) window.history.replaceState(null, '', toUrl('/'));
 
   const runTransition = !reduceMotion;
   const canTransition = runTransition && app.innerHTML.trim();
@@ -449,8 +431,8 @@ async function render(options = {}) {
   if (route.page === 'home') html = homeView();
   if (route.page === 'films') html = window.WorkPages?.filmsView?.() || '';
   if (route.page === 'film') html = window.WorkPages?.filmDetailView?.(route.id) || '';
-  if (route.page === 'writings') html = window.WorkPages?.writingsView?.() || '';
-  if (route.page === 'writing') html = window.WorkPages?.writingDetailView?.(route.slug) || '';
+  if (route.page === 'scripts') html = window.WorkPages?.scriptsView?.() || '';
+  if (route.page === 'script') html = window.WorkPages?.scriptDetailView?.(route.slug) || '';
 
   app.innerHTML = html;
   document.body.classList.toggle('home-page', route.page === 'home');
@@ -538,8 +520,8 @@ function updateActiveNav(page) {
       (page === 'home' && target === '/') ||
       (page === 'films' && target === '/films') ||
       (page === 'film' && target.startsWith('/films')) ||
-      (page === 'writings' && target.startsWith('/writings')) ||
-      (page === 'writing' && target.startsWith('/writings'));
+      (page === 'scripts' && target.startsWith('/scripts')) ||
+      (page === 'script' && target.startsWith('/scripts'));
     link.classList.toggle('is-active', active);
   });
 }
@@ -549,7 +531,7 @@ function revealElementImmediately(node) {
 }
 
 function useRevealOnce() {
-  if (document.querySelector('.page--writing-detail')) return;
+  if (document.querySelector('.page--script-detail')) return;
   const registry = animationRegistry;
   const nodes = document.querySelectorAll('[data-anim-key]');
   if (!nodes.length) return;
@@ -913,7 +895,7 @@ function runSessionLoadOverlay() {
     { at: 206, run: () => appendLine(`[${ts()}] loading module cluster: ui/net/cache`) },
     { at: 228, run: () => appendLine(`[${ts()}] validating route cache... ${routeId}`) },
     { at: 242, run: () => appendLine(`[${ts()}] warming film index...`) },
-    { at: 248, run: () => appendLine(`[${ts()}] warming writing index...`) },
+    { at: 248, run: () => appendLine(`[${ts()}] warming script index...`) },
     { at: 274, run: () => appendLine(`[${ts()}] resolving shader states...`, 'shader') },
     { at: 292, run: () => appendLine(`[${ts()}] attaching observers...`) },
     { at: 332, run: () => updateLine('shader', `[${ts()}] resolving shader states... ok`) },
@@ -1098,7 +1080,7 @@ function setupMemorySubtitle() {
   const states = {
     slate: 'a room before the story',
     films: 'images that remember',
-    writings: 'words that don\'t explain',
+    scripts: 'pages waiting for a frame',
     about: 'a person, not a pitch'
   };
 
@@ -1120,7 +1102,7 @@ function setupMemorySubtitle() {
   const sections = [
     { node: document.getElementById('slate'), line: states.slate },
     { node: document.getElementById('films'), line: states.films },
-    { node: document.querySelector('.home-writings'), line: states.writings },
+    { node: document.querySelector('.home-scripts'), line: states.scripts },
     { node: document.getElementById('about'), line: states.about }
   ].filter((entry) => entry.node);
   if (!sections.length) return;
@@ -1400,7 +1382,7 @@ function setupWhisperPulse() {
 
 function applyScrollDissolve() {
   if (reduceMotion) return;
-  const sections = document.querySelectorAll('.slate-wrap, .home-films, .home-writings, .about, .page-section');
+  const sections = document.querySelectorAll('.slate-wrap, .home-films, .home-scripts, .about, .page-section');
   if (!sections.length) return;
   const viewportCenter = window.innerHeight * 0.5;
   sections.forEach((section) => {

--- a/src/pages/script-detail.js
+++ b/src/pages/script-detail.js
@@ -1,0 +1,44 @@
+// Render an individual script and the existing styled PDF preview when available.
+(function () {
+  function escapeHtml(text) {
+    return String(text || '')
+      .replaceAll('&', '&amp;')
+      .replaceAll('<', '&lt;')
+      .replaceAll('>', '&gt;')
+      .replaceAll('"', '&quot;')
+      .replaceAll("'", '&#39;');
+  }
+
+  function pdfUrl(src) {
+    if (/^(https?:)?\/\//i.test(src) || String(src).startsWith('data:')) return src;
+    return window.AppUtils.toUrl(String(src || '').startsWith('/') ? src : `/${src}`);
+  }
+
+  function pdfPreview(item) {
+    if (!item.pdfAvailable) return '<p class="script-pdf-pending">pdf coming soon.</p>';
+    const src = pdfUrl(item.pdfUrl);
+    const title = window.AppUtils.lower(item.title);
+    return `<figure class="pdf-document-preview" data-pdf-preview data-pdf-src="${escapeHtml(src)}">
+      <a class="pdf-document-link" href="${escapeHtml(src)}" target="_blank" rel="noopener noreferrer" aria-label="open ${escapeHtml(title)} pdf">
+        <canvas class="pdf-document-canvas" data-pdf-canvas aria-hidden="true"></canvas>
+        <span class="pdf-document-placeholder" data-pdf-placeholder aria-hidden="true"></span>
+        <span class="pdf-document-open" aria-hidden="true">open pdf</span>
+      </a>
+      <figcaption><a class="pdf-document-download" href="${escapeHtml(src)}" download>download pdf</a></figcaption>
+    </figure>`;
+  }
+
+  function scriptDetailView(slug) {
+    const item = (window.APP_DATA?.scripts || []).find((entry) => entry.slug === slug);
+    if (!item) return '<section class="page-section"><h1>script not found</h1></section>';
+    return `<section class="page-section script-detail page page--script-detail">
+      <h1>${window.AppUtils.lower(item.title)}</h1>
+      ${item.synopsis ? `<p class="script-synopsis">${escapeHtml(window.AppUtils.lower(item.synopsis))}</p>` : ''}
+      ${item.year ? `<p class="script-year" aria-label="${escapeHtml(item.year)}">${escapeHtml(item.year)}</p>` : ''}
+      <article>${pdfPreview(item)}</article>
+    </section>`;
+  }
+
+  window.WorkPages = window.WorkPages || {};
+  window.WorkPages.scriptDetailView = scriptDetailView;
+})();

--- a/src/pages/scripts.js
+++ b/src/pages/scripts.js
@@ -1,0 +1,15 @@
+// Render the public scripts listing.
+(function () {
+  function scriptsView() {
+    const scripts = window.APP_DATA?.scripts || [];
+    return `<section class="page-section scripts" data-ambient-shift data-anim-key="scripts:section" data-reveal="section">
+      <h1 data-anim-key="scripts:heading" data-reveal="heading">scripts</h1>
+      <div class="script-grid" data-anim-key="scripts:grid" data-reveal="section">
+        ${scripts.map(window.AppUtils.scriptCard).join('')}
+      </div>
+    </section>`;
+  }
+
+  window.WorkPages = window.WorkPages || {};
+  window.WorkPages.scriptsView = scriptsView;
+})();

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -1,0 +1,6 @@
+// Public script metadata. Add genuine synopsis or year fields only when confirmed.
+window.SCRIPTS_DATA = [
+  { slug: 'absence', title: 'absence', pdfUrl: '/src/scripts/absence.pdf', pdfAvailable: false },
+  { slug: 'ride-home', title: 'ride home', pdfUrl: '/src/scripts/ride-home.pdf', pdfAvailable: false },
+  { slug: 'keep-it-simple', title: 'keep it simple', pdfUrl: '/src/scripts/keep-it-simple.pdf', pdfAvailable: false }
+];

--- a/styles.css
+++ b/styles.css
@@ -654,7 +654,7 @@ main {
   outline-offset: 3px;
 }
 
-.home-films, .home-writings, .about, .page-section {
+.home-films, .home-writings, .home-scripts, .about, .page-section {
   position: relative;
   margin-top: 4rem;
   padding-top: 1.1rem;
@@ -670,6 +670,7 @@ main {
 
 .home-films::before,
 .home-writings::before,
+.home-scripts::before,
 .about::before,
 .page-section::before {
   content: '';
@@ -684,6 +685,7 @@ main {
 
 .home-films::after,
 .home-writings::after,
+.home-scripts::after,
 .about::after,
 .page-section::after {
   content: '';
@@ -699,6 +701,12 @@ main {
 .film-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 1.4rem; align-items: start; }
 
 .writing-grid {
+  display: grid;
+  gap: 1.2rem;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.script-grid {
   display: grid;
   gap: 1.2rem;
   grid-template-columns: repeat(4, minmax(0, 1fr));
@@ -758,6 +766,33 @@ main {
   z-index: 1;
   pointer-events: none;
   background: linear-gradient(180deg, rgba(8, 9, 12, 0.05) 30%, rgba(8, 9, 12, 0.72) 100%);
+}
+
+.script-card .work-tile::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+  background: linear-gradient(180deg, rgba(8, 9, 12, 0.02) 22%, rgba(8, 9, 12, 0.78) 100%);
+}
+
+.script-cover {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 18% 20%, rgba(255, 211, 168, 0.12), transparent 48%),
+    radial-gradient(circle at 82% 78%, rgba(170, 181, 255, 0.1), transparent 52%),
+    linear-gradient(145deg, rgba(28, 29, 35, 0.9), rgba(9, 10, 13, 0.98));
+  transition: filter 0.16s ease-out, transform 0.16s ease-out;
+}
+
+.script-haze {
+  position: absolute;
+  inset: -20%;
+  background: linear-gradient(105deg, transparent 28%, rgba(255, 255, 255, 0.055) 50%, transparent 72%);
+  filter: blur(16px);
+  transform: rotate(-8deg);
 }
 
 .writing-composite-cover {
@@ -892,16 +927,19 @@ main {
 }
 
 .work-card-link:hover .film-image,
+.work-card-link:hover .script-cover,
 .work-card-link:hover .writing-cover-image,
 .work-card-link:hover .writing-text-cover,
 .work-card-link:hover .writing-composite-cover,
 .work-card-link:hover .thumb-placeholder,
 .work-card-link:focus-visible .film-image,
+.work-card-link:focus-visible .script-cover,
 .work-card-link:focus-visible .writing-cover-image,
 .work-card-link:focus-visible .writing-text-cover,
 .work-card-link:focus-visible .writing-composite-cover,
 .work-card-link:focus-visible .thumb-placeholder,
 .work-card-link:focus-within .film-image,
+.work-card-link:focus-within .script-cover,
 .work-card-link:focus-within .writing-cover-image,
 .work-card-link:focus-within .writing-text-cover,
 .work-card-link:focus-within .writing-composite-cover,
@@ -987,6 +1025,17 @@ main {
 
 .writing-detail article {
   width: min(100%, 760px);
+}
+
+.script-detail article {
+  width: min(100%, 760px);
+}
+
+.script-pdf-pending {
+  margin-top: 1rem;
+  color: var(--muted);
+  font-size: 0.82rem;
+  letter-spacing: 0.04em;
 }
 
 .pdf-document-preview {
@@ -1381,7 +1430,8 @@ body.slate-flash::after {
 @media (max-width: 900px) {
   body.home-page main { padding-top: 2.8rem; }
   .film-grid,
-  .writing-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .writing-grid,
+  .script-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .writing-grid .writing-card {
     --slice-count: 2;
     --slice-index: var(--slice-index-2, 0);
@@ -1395,7 +1445,8 @@ body.slate-flash::after {
     font-size: 0.68rem;
   }
   .film-grid,
-  .writing-grid { grid-template-columns: 1fr; }
+  .writing-grid,
+  .script-grid { grid-template-columns: 1fr; }
   .slate-meta {
     display: grid;
     gap: 0.25rem;


### PR DESCRIPTION
### Motivation

- Temporarily remove the public-facing “writings” surface and replace it with a lowercase “scripts” section while preserving all original writings source files and PDFs for later restoration. 
- Keep the site’s visual system, animations, routing behavior, and pdf-preview experience intact while preventing direct public access to legacy writing routes.

### Description

- Replaced the top-nav link and homepage section for `writings` with `scripts`, and stopped loading the original writings page modules in the public app by wiring the app to `scripts` data instead of `writings` (all visible labels remain lowercase).  Files changed: `index.html`, `script.js`, `styles.css`, and three new files `src/scripts.js`, `src/pages/scripts.js`, `src/pages/script-detail.js`.
- Added public `SCRIPTS_DATA` (`src/scripts.js`) with entries for `absence`, `ride home`, and `keep it simple`, each pointing to an expected PDF path but initially marked `pdfAvailable: false` so unavailable PDFs show a quiet lowercase status instead of broken links.
- Added listing and detail routes for `/scripts` and `/scripts/:slug`, created `scripts` homepage grid and scripts listing page that reuse the existing 16:9 tile/work-card system and animation hooks, and added a script detail view that reuses the site’s styled pdf-preview canvas experience when a PDF is present.
- Prevented legacy `/writings` and `/writings/:slug` routes from exposing content by resolving them to the homepage (the code replaces the URL to the home path rather than exposing raw HTML or creating redirect loops), and preserved every original writing source file (`src/writings.js` and all writing PDFs) untouched for easy restoration.

### Testing

- Ran `git diff --check` with no reported issues. (passed)
- Performed static syntax checks with `node --check` on `script.js`, `src/scripts.js`, `src/pages/scripts.js`, and `src/pages/script-detail.js` and they reported no syntax errors. (passed)
- Verified repository PDF inventory with `find . -type f -iname '*.pdf' -print` and confirmed the existing writing PDFs remain present and unchanged and that no `src/scripts/*.pdf` files existed. (checked)
- Verified `src/writings.js` and writing files were not modified. (confirmed)
- Attempted visual verification using Playwright but browser download/install failed due to an external CDN HTTP 403 in this environment, so screenshot-based checks could not be completed. (visual verification unavailable)

Notes on PDF availability

- No matching script PDFs were present; the implementation expects the following files to be added to the repo for live previews/downloads:
  - `src/scripts/absence.pdf`
  - `src/scripts/ride-home.pdf`
  - `src/scripts/keep-it-simple.pdf`

Until those files are supplied the script detail pages display a quiet lowercase “pdf coming soon.” message and do not link to or invent any documents.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a651422fc548332b9989529b3c713b7)